### PR TITLE
Add check for commit message style

### DIFF
--- a/.github/workflows/check-commit-message.yml
+++ b/.github/workflows/check-commit-message.yml
@@ -1,0 +1,25 @@
+---
+name: 'Check commit message style'
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  push:
+    branches-ignore:
+      - master
+
+jobs:
+  check-commit-message-style:
+    if: |
+      (github.actor!= 'dependabot[bot]') &&
+      (contains(github.head_ref, 'dependabot/github_actions/') == false)
+    name: Check commit message style
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check
+        uses: mristin/opinionated-commit-message@v2.2.0
+        with:
+          allow-one-liners: 'true'


### PR DESCRIPTION
Using the [opinionated-commit-message GitHub Action][1] which checks
commit messages based on the [guidelines set out by Chris Beams][2].

Runs the check on every push and pull request.

[1]: https://github.com/mristin/opinionated-commit-message
[2]: https://chris.beams.io/posts/git-commit/