### PR TITLE
Add bespoke yaml linting rules

### DIFF
--- a/.yamllint.yml
+++ b/.yamllint.yml
@@ -1,0 +1,9 @@
+---
+extends: default
+
+rules:
+  document-start: disable
+  # 120 chars should be enough, but don't fail if a line is longer
+  line-length:
+    max: 120
+    level: warning


### PR DESCRIPTION
These rules are necessary to avoid yaml linting errors on the default
petstore openapi yaml file which we will add in an upcoming commit.