### PR TITLE
Install Prism (mock server) on devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,10 @@
 FROM mcr.microsoft.com/vscode/devcontainers/universal:linux
+
+USER root
+
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+USER codespace
+
+RUN npm install -g @stoplight/prism-cli


### PR DESCRIPTION
[Prism][1] is a mock server based on OpenAPI specs.  It allows us to
run tests against any OpenAPI definition, decoupled from the
implementation of the API (for example, it means we can run tests
without there being any API implementation written yet).

[1]: https://stoplight.io/open-source/prism