### PR TITLE
Install Swagger Codegen on devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,6 +5,9 @@ USER root
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
 
+ARG SWAGGER_CODEGEN_CLI_VERSION="3.0.24"
+RUN wget "https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/${SWAGGER_CODEGEN_CLI_VERSION}/swagger-codegen-cli-${SWAGGER_CODEGEN_CLI_VERSION}.jar" -O /usr/local/bin/swagger-codegen-cli.jar
+
 USER codespace
 
 RUN npm install -g @stoplight/prism-cli


### PR DESCRIPTION
We use [Swagger Codegen][1] to generate Python SDK client code for our
OpenAPI spec.  The Python SDK client code will be used by the step
implementations for our Gauge specs.  It means that we don't need to
write much step implementation code to exercise the API, as all the
boilerplate is provided by the auto-generated SDK client code.

[1]: https://github.com/swagger-api/swagger-codegen