### PR TITLE
Use OpenAPI Generator not Swagger Codegen

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,10 +4,7 @@ USER root
 
 # RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
 #     && apt-get -y install --no-install-recommends <your-package-list-here>
-
-ARG SWAGGER_CODEGEN_CLI_VERSION="3.0.24"
-RUN wget "https://repo1.maven.org/maven2/io/swagger/codegen/v3/swagger-codegen-cli/${SWAGGER_CODEGEN_CLI_VERSION}/swagger-codegen-cli-${SWAGGER_CODEGEN_CLI_VERSION}.jar" -O /usr/local/bin/swagger-codegen-cli.jar
-    
+   
 # Install Gauge
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl -SsL https://downloads.gauge.org/stable | sh \
@@ -16,4 +13,6 @@ RUN curl -SsL https://downloads.gauge.org/stable | sh \
 
 USER codespace
 
-RUN npm install -g @stoplight/prism-cli
+RUN npm install -g @stoplight/prism-cli \
+    && npm install -g @openapitools/openapi-generator-cli
+


### PR DESCRIPTION
This commit replaces [Swagger Codegen][1] with [OpenAPI Generator][2].

Both are code generators for OpenAPI specs. [OpenAPI Generator is a fork
of Swagger CodeGen][3].

Looking at [Open Hub][4] it is clear that [OpenAPI Generator has a more
active community][5] [than Swagger Codegen][6]. And OpenAPI Generator is
a completely open source community.  So OpenAPI Generator it is.

[1]: https://swagger.io/tools/swagger-codegen/
[2]: https://openapi-generator.tech/
[3]: https://openapi-generator.tech/docs/fork-qna
[4]: https://www.openhub.net
[5]: https://www.openhub.net/p/openapi-generator
[6]: https://www.openhub.net/p/swagger-codegen